### PR TITLE
add workflow

### DIFF
--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,9 +16,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-          path: imported-action/
       - name: Debug
         run: |
-          ls -a imported-action/
+          ls -a
       - name: Check CLA issue
-        uses: ./imported-action/.github/actions/check_cla_issue/
+        uses: ./.github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/
         with:
-          issue-id: {{ github.event.number }}
+          issue-id: ${{ github.event.number }}

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -6,15 +6,14 @@ on:
   issue_comment:
 
 jobs:
-  issue_commented:
-    check-signed:
-      name: Check CLA signed
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            repository: dfinity/repositories-open-to-contributions
-            path: .github/actions/check_cla_issue/
-        - name: Check CLA issue 
-          uses: .github/actions/check_cla_issue/
+  check-signed:
+    name: Check CLA signed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: dfinity/repositories-open-to-contributions
+          path: .github/actions/check_cla_issue/
+      - name: Check CLA issue
+        uses: .github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,7 +16,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
+      - name: Debug
+        run: |
+          echo ${{ github.event.number }}
       - name: Check CLA issue
+        if: false # don't run this step until we have disabled the bot to avoid duplicate messages
         uses: ./.github/actions/check_cla_issue/
         with:
           issue-id: ${{ github.event.number }}

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -5,6 +5,8 @@ name: Check Signed
 on: 
   issue_comment:
 
+  push:
+
 jobs:
   check-signed:
     name: Check CLA signed

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-          path: ./.github/actions/check_cla_issue/action.yml
+          path: .github/actions/check_cla_issue/action.yml
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/action.yml

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -5,8 +5,6 @@ name: Check Signed
 on: 
   issue_comment:
 
-  push:
-
 jobs:
   check-signed:
     name: Check CLA signed

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -2,7 +2,7 @@
 
 name: Check Signed
 
-on: 
+on:
   issue_comment:
 
 jobs:

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-          path: .github/actions/check_cla_issue
+          path: imported-action/
       - name: Debug
         run: |
-          ls .github/actions/check_cla_issue/
+          ls -a imported-action/
       - name: Check CLA issue
-        uses: ./.github/actions/check_cla_issue/
+        uses: ./imported-action/.github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -19,6 +19,6 @@ jobs:
           path: .github/actions/check_cla_issue
       - name: Debug
         run: |
-          ls -a
+          ls .github/
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-          path: ./.github/actions/check_cla_issue/
+          path: ./.github/actions/check_cla_issue/action.yml
       - name: Check CLA issue
-        uses: ./.github/actions/check_cla_issue/
+        uses: ./.github/actions/check_cla_issue/action.yml

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -1,0 +1,20 @@
+# Workflow to check if a user has correctly signed the CLA
+
+name: Check Signed
+
+on: 
+  issue_comment:
+
+jobs:
+  issue_commented:
+    check-signed:
+      name: Check CLA signed
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            repository: dfinity/repositories-open-to-contributions
+            path: .github/actions/check_cla_issue/
+        - name: Check CLA issue 
+          uses: .github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-          path: .github/actions/check_cla_issue/
+          path: ./.github/actions/check_cla_issue/
       - name: Check CLA issue
-        uses: .github/actions/check_cla_issue/
+        uses: ./.github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -18,4 +18,4 @@ jobs:
           repository: dfinity/repositories-open-to-contributions
           path: .github/actions/check_cla_issue/action.yml
       - name: Check CLA issue
-        uses: ./.github/actions/check_cla_issue/action.yml
+        uses: .github/actions/check_cla_issue/action.yml

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-          path: .github/actions/check_cla_issue/action.yml
+          path: .github/actions/check_cla_issue
       - name: Check CLA issue
-        uses: .github/actions/check_cla_issue/action.yml
+        uses: ./.github/actions/check_cla_issue

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/
         with:
-          issue-id: 208
+          issue-id: {{ github.event.number }}

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -19,6 +19,6 @@ jobs:
           path: .github/actions/check_cla_issue
       - name: Debug
         run: |
-          ls .github/
+          ls .github/actions/check_cla_issue/
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -16,8 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-      - name: Debug
-        run: |
-          ls -a
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/
+        with:
+          issue-id: 208

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -18,4 +18,4 @@ jobs:
           repository: dfinity/repositories-open-to-contributions
           path: .github/actions/check_cla_issue
       - name: Check CLA issue
-        uses: ./.github/actions/check_cla_issue
+        uses: ./.github/actions/check_cla_issue/

--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -17,5 +17,8 @@ jobs:
         with:
           repository: dfinity/repositories-open-to-contributions
           path: .github/actions/check_cla_issue
+      - name: Debug
+        run: |
+          ls -a
       - name: Check CLA issue
         uses: ./.github/actions/check_cla_issue/


### PR DESCRIPTION
This workflow runs when an issue is commented on. I'm not sure how to test out the trigger, which is why I added a debug step and will verify if it runs when issues are commented on. I tested that the workflow can create comments by manually passing in an issue ID and it worked - you can see that the comment is now generated by `github-actions`: https://github.com/dfinity/cla/issues/208

This action can't be turned on until the `cla-bot` has been deactivated to avoid duplicate comments.