### PR TITLE
enable cla check

### DIFF
--- a/.github/workflows/check_signed.yml
+++ b/.github/workflows/check_signed.yml
@@ -14,12 +14,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: dfinity/repositories-open-to-contributions
-      - name: Debug
-        run: |
-          echo ${{ github.event_name }}
-          echo ${{ github.event.issue.number }}
       - name: Check CLA issue
-        if: false # don't run this step until we have disabled the bot to avoid duplicate messages
         uses: ./.github/actions/check_cla_issue/
         with:
           issue-id: ${{ github.event.issue.number }}


### PR DESCRIPTION
We now create a separate label if the issue was generated by the new workflow so it is safe to enable this step.